### PR TITLE
Fixed that typo that's always bothered me

### DIFF
--- a/designguide.html
+++ b/designguide.html
@@ -69,7 +69,7 @@
         file has this header:<br>
         <font size="2" face="Courier New, Courier, mono">#The Triton
           Center<br>
-          #Copyright ©2002-2013 Ryan Thoryk</font></p>
+          #Copyright Â©2002-2013 Ryan Thoryk</font></p>
       <p align="left"><br>
         <strong>2. Variables</strong></p>
       <p align="left">Variables are marked with percent signs (%), and
@@ -754,7 +754,7 @@ manual's
         always be enabled.</p>
       <p align="left"><strong>7. AddTextRange</strong> - similar to
         LoadRange, but draws text onto a texture<br>
-        Syntax: <font size="2" face="Courier New, Courier, mono">AddText
+        Syntax: <font size="2" face="Courier New, Courier, mono">AddTextRange
 
 
 
@@ -769,7 +769,7 @@ manual's
           <em>startnumber, endnumber, texture_name, name, font_filename,
             font_size, text, x1, y1, x2, y2, h_align, v_align, ColorR,
             ColorG, ColorB[, force</em></font><em>]<br>
-        </em>Example: <font size="2" face="Courier New, Courier, mono">AddText
+        </em>Example: <font size="2" face="Courier New, Courier, mono">AddTextRange
 
 
 


### PR DESCRIPTION
AddTextRange example said "AddText", corrected to "AddTextRange".

It's always annoyed me for years, but I have no idea how long it's been there. There's probably other typos too, but I can't think of any others that I've seen.