### PR TITLE
Fix gitrev.cmd script

### DIFF
--- a/gitrev.cmd
+++ b/gitrev.cmd
@@ -1,11 +1,9 @@
-echo off
+@echo off
 echo Generating GitRev header...
-erase src\sbs\gitrev.h
-echo #ifndef GITREV_H>> src\sbs\gitrev.h
+echo #ifndef GITREV_H> src\sbs\gitrev.h
 echo #define GITREV_H>> src\sbs\gitrev.h
 echo.>> src\sbs\gitrev.h
-git rev-list HEAD | find /c /v "" > out
-set /p VV=<out
-echo #define GIT_REV %VV%>> src\sbs\gitrev.h
-erase out
+echo|set /p="#define GIT_REV ">> src\sbs\gitrev.h
+git rev-list HEAD | find /c /v "">> src\sbs\gitrev.h
+echo.>> src\sbs\gitrev.h
 echo #endif>> src\sbs\gitrev.h

--- a/msvc/SBS.vcxproj
+++ b/msvc/SBS.vcxproj
@@ -329,6 +329,7 @@
     <ClInclude Include="..\src\sbs\escalator.h" />
     <ClInclude Include="..\src\sbs\floor.h" />
     <ClInclude Include="..\src\sbs\floorindicator.h" />
+    <ClInclude Include="..\src\sbs\gitrev.h" />
     <ClInclude Include="..\src\sbs\globals.h" />
     <ClInclude Include="..\src\sbs\indicator.h" />
     <ClInclude Include="..\src\sbs\light.h" />


### PR DESCRIPTION
Script would produce an "Access is denied" error on my Windows 7 machine (might have worked fine on later versions of Windows). I fixed this.
Also made it so it doesn't error if the file doesn't exist.
Also added include for the gitrev.h file to the SBS.vcxproj project.

It would probably also be a good idea to mention in the Compilng.md file that you have to run this script, otherwise it will fail to compile because it can't find gitrev.h.