### PR TITLE
Some Fixes and Changes

### DIFF
--- a/designguide.html
+++ b/designguide.html
@@ -5981,7 +5981,7 @@ filename,
           1 = chime.wav</font></p>
       <p align="left"><strong>19. EarlyDownChimeSound</strong> - the
         sound file to play during an early arrival notification of the
-        elevator, and the direction is up. Default is <em>chime1-down.wav</em>.
+        elevator, and the direction is down. Default is <em>chime1-down.wav</em>.
         Leave the filename field blank for no sound. This must be
         specified after the CreateCar command.<br>
         Syntax: <font face="Courier New, Courier, mono" size="2">EarlyDownChimeSound

--- a/src/sbs/action.cpp
+++ b/src/sbs/action.cpp
@@ -380,6 +380,8 @@ bool Action::Run(Object *caller, Object *parent, bool &hold)
 		//}
 		if (command_name == "cancel" && elevator->FireServicePhase2 == 1)
 			return elevator->CallCancel();
+		if (command_name == "cancel" && elevator->IndependentService == true)
+			return elevator->CallCancel();
 		if (command_name == "run")
 		{
 			elevator->SetRunState(true);

--- a/src/sbs/elevator.cpp
+++ b/src/sbs/elevator.cpp
@@ -727,8 +727,7 @@ bool Elevator::RouteExists(bool direction, int floor)
 
 bool Elevator::CallCancel()
 {
-	//cancels the last added route
-	//LastQueueFloor holds the floor and direction of the last route; array element 0 is the floor and 1 is the direction
+	//cancels all added routes
 
 	if (Running == false)
 		return ReportError("Elevator not running");
@@ -736,14 +735,12 @@ bool Elevator::CallCancel()
 	if (LastQueueFloor[1] == 0)
 	{
 		if (sbs->Verbose)
-			ReportError("CallCancel: route not valid");
+			ReportError("CallCancel: no valid routes");
 		return false;
 	}
 
-	Report("cancelled last call");
-	DeleteRoute(LastQueueFloor[0], LastQueueFloor[1]);
-	LastQueueFloor[0] = 0;
-	LastQueueFloor[1] = 0;
+	Report("cancelled all calls");
+        ResetQueue(true, true);
 	return true;
 }
 

--- a/src/sbs/elevatorcar.cpp
+++ b/src/sbs/elevatorcar.cpp
@@ -2641,8 +2641,8 @@ bool ElevatorCar::PlayMessageSound(bool type)
 			if (parent->LastChimeDirection == 0)
 				direction = parent->LastQueueDirection;
 		}
-		//else
-			//direction = parent->ActiveDirection;
+		else
+			direction = parent->ActiveDirection;
 
 		if (direction == 1)
 		{

--- a/src/sbs/elevatorcar.cpp
+++ b/src/sbs/elevatorcar.cpp
@@ -2642,7 +2642,7 @@ bool ElevatorCar::PlayMessageSound(bool type)
 				direction = parent->LastQueueDirection;
 		}
 		else
-			direction = parent->LastChimeDirection;
+			direction = parent->ActiveDirection;
 
 		if (direction == 1)
 		{

--- a/src/sbs/elevatorcar.cpp
+++ b/src/sbs/elevatorcar.cpp
@@ -2642,7 +2642,7 @@ bool ElevatorCar::PlayMessageSound(bool type)
 				direction = parent->LastQueueDirection;
 		}
 		else
-			direction = parent->ActiveDirection;
+			direction = parent->LastChimeDirection;
 
 		if (direction == 1)
 		{

--- a/src/sbs/elevatorcar.cpp
+++ b/src/sbs/elevatorcar.cpp
@@ -2641,8 +2641,8 @@ bool ElevatorCar::PlayMessageSound(bool type)
 			if (parent->LastChimeDirection == 0)
 				direction = parent->LastQueueDirection;
 		}
-		else
-			direction = parent->ActiveDirection;
+		//else
+			//direction = parent->ActiveDirection;
 
 		if (direction == 1)
 		{

--- a/src/sbs/elevatorcar.cpp
+++ b/src/sbs/elevatorcar.cpp
@@ -1193,7 +1193,7 @@ bool ElevatorCar::OpenDoors(int number, int whichdoors, int floor, bool manual, 
 	{
 		//if elevator is moving and interlocks are enabled, stop elevator
 		if (parent->IsMoving == true && parent->OnFloor == false)
-			parent->Stop(false);
+			parent->Stop(true);
 	}
 
 	int start = number, end = number;


### PR DESCRIPTION
Here are a few quick fixes and changes that I made before the v2.0 stable release. None of these fixes have been tested yet, so results may vary.

- Fixed Call Cancel to cancel all calls and not just the last added call.
- Opening an elevator door with interlocks enabled now emergency stops the elevator.
- Have the directional message sound even when the elevator is called on the same floor. (Not sure if this will function properly, so I commented out what happened before instead of deleting it altogether.)
- Call Cancel now works when an elevator is in Independent Service.
- Fixed minor typo in EarlyDownChimeSound section.