### PR TITLE
Additional Directional Message fixes

### DIFF
--- a/src/sbs/elevatorcar.cpp
+++ b/src/sbs/elevatorcar.cpp
@@ -2624,13 +2624,7 @@ bool ElevatorCar::PlayMessageSound(bool type)
 
 	if (parent->IsQueueActive() == false && type == true && MessageOnClose == true)
 		return false;
-
-	if (parent->LastChimeDirection == 0 && type == true)
-		return false;
-
-	if (parent->NotifyLate == false && type == true && parent->NotifyEarly == -1)
-		return false;
-
+	
 	std::string newsound;
 
 	if (type == true)
@@ -2643,6 +2637,12 @@ bool ElevatorCar::PlayMessageSound(bool type)
 
 		if (MessageOnMove == false)
 		{
+			if (parent->LastChimeDirection == 0 && type == true)
+				return false;
+
+			if (parent->NotifyLate == false && type == true && parent->NotifyEarly == -1)
+				return false;
+			
 			direction = parent->LastChimeDirection;
 
 			if (parent->LastChimeDirection == 0)

--- a/src/sbs/elevatorcar.cpp
+++ b/src/sbs/elevatorcar.cpp
@@ -2625,6 +2625,12 @@ bool ElevatorCar::PlayMessageSound(bool type)
 	if (parent->IsQueueActive() == false && type == true && MessageOnClose == true)
 		return false;
 
+	if (parent->LastChimeDirection == 0 && type == true)
+		return false;
+
+	if (parent->NotifyLate == false && type == true && parent->NotifyEarly == -1)
+		return false;
+
 	std::string newsound;
 
 	if (type == true)

--- a/src/sbs/elevatordoor.cpp
+++ b/src/sbs/elevatordoor.cpp
@@ -755,13 +755,13 @@ void ElevatorDoor::MoveDoors(bool open, bool manual)
 				car->Report("not resetting timer for door" + GetNumberText() + " due to blocked sensor");
 		}
 
-		//play direction message sound
-		if (car->MessageOnMove == false && car->MessageOnStart == false && car->MessageOnClose == false)
-			car->PlayMessageSound(true);
-
 		//play late arrival notification if specified
 		if (elev->NotifyLate == true)
 			car->NotifyArrival(car->GetFloor());
+
+		//play direction message sound
+		if (car->MessageOnMove == false && car->MessageOnStart == false && car->MessageOnClose == false)
+			car->PlayMessageSound(true);
 	}
 	else
 	{


### PR DESCRIPTION
These are some more directional message fixes, which includes a fix for NotifyLate. Before this fix, the directional message would default to down on startup, even if the elevator had an up call on the same floor.