### PR TITLE
AddElevatorIDSigns command and fix to keypad indicators

### DIFF
--- a/designguide.html
+++ b/designguide.html
@@ -374,6 +374,7 @@
 
 
 
+
           = <em>X</em>, <em>Z</em></font><br>
         <font size="2" face="Courier New, Courier, mono">CameraPosition
           = 0, -10</font><br>
@@ -389,6 +390,7 @@
         left/right, and Z is spin. Default is "0, 0, 0", and the example
         makes the camera face right.<br>
         Syntax: <font size="2" face="Courier New, Courier, mono">CameraRotation
+
 
 
 
@@ -431,6 +433,7 @@
           RainWind<br>
         </font></p>
       <p style="text-align:left;margin-left:0;margin-right:auto;">Available
+
 
 
 
@@ -537,8 +540,10 @@
 
 
 
+
           = <em>X, Y, Z</em></font><br>
         Example: <font size="2" face="Courier New, Courier, mono">Position
+
 
 
 
@@ -595,8 +600,10 @@
 
 
 
+
           = <em>value</em></font><br>
         Example: <font size="2" face="Courier New, Courier, mono">Rotation
+
 
 
 
@@ -632,6 +639,7 @@
         Syntax: <font size="2" face="Courier New, Courier, mono">Bounds
           = <em>MinX, MinY, MinZ, MaxX, MaxY, MaxZ</em></font><br>
         Example: <font size="2" face="Courier New, Courier, mono">Bounds
+
 
 
 
@@ -710,9 +718,11 @@
 
 
 
+
           <em>startnumber</em>, <em>endnumber</em>, <em>filename</em>,
           <em>name</em>, <em>tile_x</em>, <em>tile_y[, force] </em></font><br>
         Example: <font size="2" face="Courier New, Courier, mono">LoadRange
+
 
 
 
@@ -776,9 +786,11 @@
 
 
 
+
           LoadAnimated</strong> - loads a set of textures to use as a
         single animated texture<br>
         Syntax: <font size="2" face="Courier New, Courier, mono">LoadAnimated
+
 
 
 
@@ -849,10 +861,12 @@
 
 
 
+
           LoadAlphaBlend</strong> - loads a texture with a specular mask
         texture and blending texture, used to make things like
         reflection effects<br>
         Syntax: <font size="2" face="Courier New, Courier, mono">LoadAlphaBlend
+
 
 
 
@@ -924,9 +938,11 @@
 
 
 
+
           LoadMaterial</strong> - loads a custom OGRE material, used for
         advanced/specific texture definitions<br>
         Syntax: <font size="2" face="Courier New, Courier, mono">LoadMaterial
+
 
 
 
@@ -993,6 +1009,7 @@ manual's
 
 
 
+
           "Material Scripts" section</a>.</p>
       <p align="left"><strong>6. AddText</strong> - draws text onto a
         texture - this only creates a new texture during runtime (in
@@ -1024,9 +1041,11 @@ manual's
 
 
 
+
           <em>texture_name, name, font_filename, font_size, text, x1,
             y1, x2, y2, h_align, v_align, ColorR, ColorG, ColorB[, force</em></font><em>]<br>
         </em>Example: <font size="2" face="Courier New, Courier, mono">AddText
+
 
 
 
@@ -1104,10 +1123,12 @@ manual's
 
 
 
+
           <em>startnumber, endnumber, texture_name, name, font_filename,
             font_size, text, x1, y1, x2, y2, h_align, v_align, ColorR,
             ColorG, ColorB[, force</em></font><em>]<br>
         </em>Example: <font size="2" face="Courier New, Courier, mono">AddText
+
 
 
 
@@ -1163,10 +1184,12 @@ manual's
 
 
 
+
           <em>filename, name, x, y, width, height, tile_x, tile_y[,
             force</em></font><em>]<br>
         </em>Example: <font size="2" face="Courier New, Courier, mono">LoadCropped
 data\brick1.jpg,
+
 
 
 
@@ -1230,10 +1253,12 @@ data\brick1.jpg,
 
 
 
+
           <em>texture_name, overlay_texture_name, name, x, y, width,
             height, tile_x, tile_y[, force]</em></font><em><br>
         </em>Example: <font size="2" face="Courier New, Courier, mono">AddOverlay
 Brick1,
+
 
 
 
@@ -1313,9 +1338,11 @@ Brick1,
 
 
 
+
           RotateAnim</strong> - applies rotation animation to a texture.
         This can be used with other texture modifiers.<br>
         Syntax: <font size="2" face="Courier New, Courier, mono">RotateAnim
+
 
 
 
@@ -1349,6 +1376,7 @@ Brick1,
         example, the Brick1 texture's rotation animation is set to 0.2
         rotations per second.</p>
       <p style="text-align:left;margin-left:0;margin-right:auto;"><strong>12.
+
 
 
 
@@ -1409,9 +1437,11 @@ Brick1,
 
 
 
+
           ScrollAnim</strong> - applies scrolling animation to a
         texture. This can be used with other texture modifiers.<br>
         Syntax: <font size="2" face="Courier New, Courier, mono">ScrollAnim
+
 
 
 
@@ -1444,6 +1474,7 @@ Brick1,
         scrolls per second. In the example, the Brick1 texture will
         scroll to the right once per second, and up once per second.</p>
       <p style="text-align:left;margin-left:0;margin-right:auto;"><strong>14.
+
 
 
 
@@ -1503,11 +1534,13 @@ Brick1,
 
 
 
+
           Transform</strong> - sets an advanced transformation method on
         the texture. This can be used with other texture modifiers, and
         also can be used multiple times to create multiple
         transformations.<br>
         Syntax: <font size="2" face="Courier New, Courier, mono">Transform
+
 
 
 
@@ -1688,6 +1721,7 @@ Brick1,
 
 
 
+
           = 2.24</font></p>
       <p align="left"><strong>7. Altitude</strong> - this parameter is
         optional and is only recommended if the first level has an
@@ -1738,11 +1772,13 @@ Brick1,
 
 
 
+
           <em>name, texturename</em>, <em>thickness, x1</em>, <em>z1</em>,
           <em>x2</em>, <em>z2</em>, <em>voffset1</em>, <em>voffset2,
             reverse_axis, texture_direction, tw</em>, <em>th,
             isexternal</em></font><br>
         Example: <font size="2" face="Courier New, Courier, mono">AddFloor
+
 
 
 
@@ -1814,11 +1850,13 @@ Brick1,
 
 
 
+
           <em>name, texturename</em>, <em>thickness, x1</em>, <em>z1</em>,
           <em>x2</em>, <em>z2</em>, <em>height1</em>, <em>height2</em>,
           <em>voffset1</em>, <em>voffset2</em>, <em>tw</em>, <em>th</em>,
           <em>isexternal</em></font><br>
         Example: <font size="2" face="Courier New, Courier, mono">AddWall
+
 
 
 
@@ -1884,10 +1922,12 @@ Brick1,
 
 
 
+
           <em>name, texturename</em>, <em>thickness, x1</em>, <em>z1</em>,
           <em>x2</em>, <em>z2</em>, <em>voffset1</em>, <em>voffset2,
             reverse_axis, texture_direction, tw</em>, <em>th</em></font><br>
         Example: <font size="2" face="Courier New, Courier, mono">AddInterfloorFloor
+
 
 
 
@@ -1921,6 +1961,7 @@ Brick1,
       <p align="left"><strong>5. AddInterfloorWall</strong> - adds a
         textured wall below the floor of the current floor/level<br>
         Syntax: <font size="2" face="Courier New, Courier, mono">AddInterfloorWall
+
 
 
 
@@ -1980,10 +2021,12 @@ Brick1,
 
 
 
+
           <em>number, name, texturename</em>, <em>thickness, x1</em>, <em>z1</em>,
           <em>x2</em>, <em>z2</em>, <em>voffset1</em>, <em>voffset2,
             reverse_axis, texture_direction, tw</em>, <em>th</em></font><br>
         Example: <font size="2" face="Courier New, Courier, mono">AddShaftFloor
+
 
 
 
@@ -2019,6 +2062,7 @@ Brick1,
       <p align="left"><strong>7. AddShaftWall</strong> - adds a textured
         wall to the specified shaft, on the current floor<br>
         Syntax: <font size="2" face="Courier New, Courier, mono">AddShaftWall
+
 
 
 
@@ -2080,10 +2124,12 @@ Brick1,
 
 
 
+
           <em>number, name, texturename</em>, <em>thickness, x1</em>, <em>z1</em>,
           <em>x2</em>, <em>z2</em>, <em>voffset1</em>, <em>voffset2,
             reverse_axis, texture_direction, tw</em>, <em>th</em></font><br>
         Example: <font size="2" face="Courier New, Courier, mono">AddStairsFloor
+
 
 
 
@@ -2117,6 +2163,7 @@ Brick1,
       <p align="left"><strong>9. AddStairsWall</strong> - adds a
         textured wall to the specified stairwell, on the current floor<br>
         Syntax: <font size="2" face="Courier New, Courier, mono">AddStairsWall
+
 
 
 
@@ -2179,10 +2226,12 @@ Brick1,
 
 
 
+
           <em>name, texturename</em>, <em>x1</em>, <em>x2</em>, <em>z1</em>,
           <em>z2</em>, <em>height</em>, <em>voffset</em>, <em>tw</em>,
           <em>th, inside, outside, top, bottom </em></font><br>
         Example: <font size="2" face="Courier New, Courier, mono">ColumnWallBox
+
 
 
 
@@ -2242,10 +2291,12 @@ Brick1,
 
 
 
+
           <em>name, texturename</em>, <em>centerx</em>, <em>centerz</em>,
           <em>widthx</em>, <em>lengthz</em>, <em>height</em>, <em>voffset</em>,
           <em>tw</em>, <em>th</em><em>, inside, outside, top, bottom </em></font><br>
         Example: <font size="2" face="Courier New, Courier, mono">ColumnWallBox2
+
 
 
 
@@ -2305,6 +2356,7 @@ Brick1,
 
 
 
+
           = 1, 2, 3, 4<br>
         </font> Example: <font size="2" face="Courier New, Courier,
           mono">CallButtonElevators = 1 - 4</font><br>
@@ -2312,6 +2364,7 @@ Brick1,
       <p align="left"><strong>13. CreateCallButtons</strong> - creates a
         call button set<br>
         Syntax: <font size="2" face="Courier New, Courier, mono">CreateCallButtons
+
 
 
 
@@ -2417,10 +2470,12 @@ Brick1,
 
 
 
+
           <em>number, name, riser_texture, tread_texture, direction,
             CenterX, CenterZ, width, risersize, treadsize, num_stairs,
             voffset, tw, th</em></font><br>
         Example: <font size="2" face="Courier New, Courier, mono">AddStairs
+
 
 
 
@@ -2468,6 +2523,7 @@ Brick1,
         door in the specified location, and performs a wall cut on that
         area (this must be called after the associated wall is created)<br>
         Syntax: <font size="2" face="Courier New, Courier, mono">AddDoor
+
 
 
 
@@ -2547,6 +2603,7 @@ Brick1,
 
 
 
+
           <em>number, opensound, closesound, open, texturename,
             thickness</em>, <em>direction, speed, CenterX</em>, <em>CenterZ</em>,
           <em>width</em>, <em>height</em>, <em>voffset</em>, <em>tw</em>,
@@ -2582,6 +2639,7 @@ Brick1,
 
 
 
+
           AddShaftStdDoor</strong> - adds a standard textured door for
         the specified shaft, in a location relative to the shaft's
         center. This also performs a wall cut on that area (this must be
@@ -2589,6 +2647,7 @@ Brick1,
         confused with the AddShaftDoor command, which creates elevator
         shaft doors.<br>
         Syntax: <font size="2" face="Courier New, Courier, mono">AddShaftStdDoor
+
 
 
 
@@ -2654,6 +2713,7 @@ Brick1,
 
 
 
+
           <em>opensound, closesound, open, texturename, thickness</em>,
           <em>direction, speed, CenterX</em>, <em>CenterZ</em>, <em>width</em>,
           <em>height</em>, <em>voffset</em>, <em>tw</em>, <em>th<br>
@@ -2665,6 +2725,7 @@ Brick1,
         creates a single elevator directional indicator/lantern on the
         current floor (similar to the CreateCallButtons command) <br>
         Syntax: <font size="2" face="Courier New, Courier, mono">AddDirectionalIndicator<em>&nbsp;Elevator:Car,
+
 
 
 
@@ -2773,10 +2834,12 @@ Brick1,
 
 
 
+
             number, lefttexture, righttexture</em>, <em>thickness,
             CenterX, CenterZ, voffset, tw, th</em></font><br>
         Syntax (with old SetShaftDoors command): <font size="2"
           face="Courier New, Courier, mono">AddShaftDoor<em>&nbsp;elevator,
+
 
 
 
@@ -2833,6 +2896,7 @@ Brick1,
 
 
 
+
             relative, texture_prefix, blank_texture, direction, CenterX,
             CenterZ, width, height, voffset</em></font> </p>
       <p align="left">The AddFloorIndicator command creates a floor
@@ -2852,6 +2916,7 @@ Brick1,
       <p align="left"><strong>22. Cut</strong> - performs a manual box
         cut on an area within the current floor<br>
         Syntax: <font size="2" face="Courier New, Courier, mono">Cut <em>x1,
+
 
 
 
@@ -2929,6 +2994,7 @@ Brick1,
 
 
 
+
           <em>texture, thickness, CenterX, CenterZ, width, height,
             voffset, direction, tw, th, isexternal</em><br>
         </font>Example: <font size="2" face="Courier New, Courier,
@@ -2944,6 +3010,7 @@ Brick1,
       <p align="left"><strong>25. AddSound</strong> - creates a
         user-defined sound at the specified position<br>
         Syntax: <font size="2" face="Courier New, Courier, mono">AddSound
+
 
 
 
@@ -2999,6 +3066,7 @@ Brick1,
 
 
 
+
           MySound, sound.wav, 10, 100, 5, true<br>
         </font>Example 2: <font size="2" face="Courier New, Courier,
           mono">AddSound MySound, sound.wav, 10, 100, 5, true, 1, 100,
@@ -3012,6 +3080,7 @@ Brick1,
         creates a single shaft door component, used for creating custom
         door styles<br>
         Syntax: <font size="2" face="Courier New, Courier, mono">AddShaftDoorComponent
+
 
 
 
@@ -3081,12 +3150,14 @@ Brick1,
 
 
 
+
             number[, door_walls, track_walls]</em></font></p>
       <p align="left">This command is almost identical to the
         FinishDoors command (in the elevator section below - see that
         for more information) except that it's used for finishing a
         shaft door.</p>
       <p style="text-align:left;margin-left:0;margin-right:auto;"><strong>28.
+
 
 
 
@@ -3148,6 +3219,7 @@ filename,
 
 
 
+
             center, CenterX, CenterY, CenterZ, RotationX, RotationY,
             RotationZ, MaxRenderDistance, ScaleMultiplier,
             EnablePhysics, Restitution, Friction, Mass</em><em><br>
@@ -3180,9 +3252,11 @@ filename,
 
 
 
+
           MyModel, cube.mesh, true, 0, 0, 0, 0, 0, 0, 0, 1, true, 0.1,
           0.5, 0.1</font><br>
         Example 3:<font size="2" face="Courier New, Courier, mono">&nbsp;AddModel
+
 
 
 
@@ -3255,6 +3329,7 @@ filename,
 
 
 
+
             name, filename, center, CenterX, CenterY, CenterZ,
             RotationX, RotationY, RotationZ, MaxRenderDistance,
             ScaleMultiplier, EnablePhysics, Restitution, Friction, Mass</em><em><br>
@@ -3267,6 +3342,7 @@ filename,
         model to the specified shaft, on the current floor. See the
         AddModel command above for parameter information.<br>
         Syntax: <font size="2" face="Courier New, Courier, mono">AddShaftModel<em>&nbsp;number,
+
 
 
 
@@ -3326,9 +3402,11 @@ filename,
 
 
 
+
           AddActionControl</strong> - creates a custom control that uses
         a specific action defined by AddAction.<br>
         Syntax: <font size="2" face="Courier New, Courier, mono">AddActionControl
+
 
 
 
@@ -3401,10 +3479,12 @@ filename,
 
 
 
+
           AddShaftActionControl</strong> - creates a custom control in a
         specified shaft that uses a specific action defined by
         AddAction.<br>
         Syntax: <font size="2" face="Courier New, Courier, mono">AddShaftActionControl
+
 
 
 
@@ -3477,10 +3557,12 @@ filename,
 
 
 
+
           AddStairsActionControl</strong> - creates a custom control in
         a specified stairwell that uses a specific action defined by
         AddAction.<br>
         Syntax: <font size="2" face="Courier New, Courier, mono">AddStairsActionControl
+
 
 
 
@@ -3553,10 +3635,12 @@ filename,
 
 
 
+
           AddTrigger</strong> - creates a trigger that is used to signal
         an action when the user's camera enters or leaves the defined
         area.<br>
         Syntax:&nbsp;<font size="2" face="Courier New, Courier, mono">AddTrigger
+
 
 
 
@@ -3625,7 +3709,9 @@ filename,
 
 
 
+
           <em>name, run, sound, texturename, thickness</em>, <em>clockwise,
+
 
 
 
@@ -3678,10 +3764,12 @@ filename,
 
 
 
+
           <em>name, run, speed, sound_file, riser_texture,
             tread_texture, direction, CenterX, CenterZ, width,
             risersize, treadsize, num_steps, voffset, tw, th</em></font><br>
         Example: <font size="2" face="Courier New, Courier, mono">AddEscalator
+
 
 
 
@@ -3753,9 +3841,11 @@ filename,
 
 
 
+
           <em>name, run, speed, sound_file, texture, direction, CenterX,
             CenterZ, width, treadsize, num_steps, voffset, tw, th</em></font><br>
         Example: <font size="2" face="Courier New, Courier, mono">AddMovingWalkway
+
 
 
 
@@ -3876,10 +3966,12 @@ filename,
 
 
 
+
           = 0.015</font></p>
       <p align="left"><strong>4b. AccelJerk</strong> - acceleration jerk
         rate of the elevator (rate of change of acceleration)<br>
         Example: <font size="2" face="Courier New, Courier, mono">AccelJerk
+
 
 
 
@@ -3934,6 +4026,7 @@ filename,
 
 
 
+
           = 0.0075</font></p>
       <p align="left"><strong>5b. DecelJerk</strong> - deceleration jerk
         rate of the elevator (rate of change of deceleration)<br>
@@ -3963,10 +4056,12 @@ filename,
 
 
 
+
           = 1.0</font></p>
       <p align="left"><strong>6. AssignedShaft</strong> - the shaft
         number this elevator is in<br>
         Example: <font size="2" face="Courier New, Courier, mono">AssignedShaft
+
 
 
 
@@ -4026,6 +4121,7 @@ filename,
 
 
 
+
           = start.wav</font></p>
       <p align="left"><strong>8. MotorRunSound, MotorUpRunSound,
           MotorDownRunSound</strong> - the sound file to play while the
@@ -4035,6 +4131,7 @@ filename,
         specifies both up and down sounds, while the others are for
         either upwards movement or downwards movement.<br>
         Example: <font size="2" face="Courier New, Courier, mono">MotorRunSound
+
 
 
 
@@ -4094,11 +4191,13 @@ filename,
 
 
 
+
           = stop.wav</font></p>
       <p align="left"><strong>10. MotorIdleSound</strong> - the sound
         file to play when the elevator motor is idling. There is no
         default yet. Leave the filename field blank for no sound. <br>
         Example: <font size="2" face="Courier New, Courier, mono">MotorIdleSound
+
 
 
 
@@ -4159,11 +4258,13 @@ filename,
 
 
 
+
           = EZ </font></p>
       <p align="left"><strong>12. RecallFloor</strong> - sets the floor
         the elevator will recall to during fire service phase 1 mode.
         Default is the lowest serviced floor. <br>
         Example: <font size="2" face="Courier New, Courier, mono">RecallFloor
+
 
 
 
@@ -4195,6 +4296,7 @@ filename,
         service phase 1 mode. Default is the highest serviced floor. <br>
         Example: <font size="2" face="Courier New, Courier, mono">AlternateRecallFloor
 =
+
 
 
 
@@ -4254,6 +4356,7 @@ filename,
 
 
 
+
           = 5</font></p>
       <p align="left"><strong>16. MotorPosition</strong> - sets the
         position of the motor sound emitter; if this command is not
@@ -4261,6 +4364,7 @@ filename,
         of the highest floor in the corresponding shaft. The X and Z
         values are relative of the elevator center.<br>
         Syntax: <font size="2" face="Courier New, Courier, mono">MotorPosition
+
 
 
 
@@ -4323,6 +4427,7 @@ filename,
 
 
 
+
           = true</font></p>
       <p align="left"><strong>18. LimitQueue</strong> - set this to true
         to only allow floor selections in the same direction as the
@@ -4332,6 +4437,7 @@ filename,
         will only be available for hall calls in the active queue
         direction.<br>
         Example: <font size="2" face="Courier New, Courier, mono">LimitQueue
+
 
 
 
@@ -4386,10 +4492,12 @@ filename,
 
 
 
+
           = true</font></p>
       <p align="left"><strong>20. DownPeak</strong> - enables down peak
         mode for this elevator.<br>
         Example: <font size="2" face="Courier New, Courier, mono">DownPeak
+
 
 
 
@@ -4444,8 +4552,10 @@ filename,
 
 
 
+
           = true</font></p>
       <p style="text-align:left;margin-left:0;margin-right:auto;"><strong>22.
+
 
 
 
@@ -4499,8 +4609,10 @@ filename,
 
 
 
+
           = <em>multiplier</em></font></p>
       <p style="text-align:left;margin-left:0;margin-right:auto;"><strong>23.
+
 
 
 
@@ -4556,10 +4668,12 @@ filename,
 
 
 
+
           = <em>floor, delay</em></font></p>
       <p align="left"><strong>24. LevelingSpeed</strong> - elevator's
         leveling speed. Default is 0.2<br>
         Syntax: <font size="2" face="Courier New, Courier, mono">LevelingSpeed
+
 
 
 
@@ -4615,11 +4729,13 @@ filename,
 
 
 
+
           = <em>distance</em></font></p>
       <p align="left"><strong>26. LevelingOpen</strong> - distance in
         feet from the destination floor that the elevator will open the
         doors. Default is 0.<br>
         Syntax: <font size="2" face="Courier New, Courier, mono">LevelingOpen
+
 
 
 
@@ -4680,6 +4796,7 @@ filename,
 
 
 
+
           = <em>value</em></font></p>
       <p align="left"><strong>28. NotifyLate</strong> - if set to true,
         the elevator car performs an arrival notification (chime,
@@ -4711,11 +4828,13 @@ filename,
 
 
 
+
           = <em>value</em></font></p>
       <p align="left"><strong>29. DepartureDelay</strong> - sets the
         time in seconds that the elevator waits before proceeding to the
         next floor. Default is 0.<br>
         Syntax: <font size="2" face="Courier New, Courier, mono">DepartureDelay
+
 
 
 
@@ -4772,6 +4891,7 @@ filename,
 
 
 
+
           = <em>0.5</em></font></p>
       <p align="left"><strong>31. FireService1</strong> - sets the fire
         service phase 1 mode that the elevator will start with. Default
@@ -4802,8 +4922,10 @@ filename,
 
 
 
+
           = 2</font></p>
       <p style="text-align:left;margin-left:0;margin-right:auto;"><strong>32.
+
 
 
 
@@ -4859,8 +4981,10 @@ filename,
 
 
 
+
           = false</font></p>
       <p style="text-align:left;margin-left:0;margin-right:auto;"><strong>33.
+
 
 
 
@@ -4914,8 +5038,10 @@ filename,
 
 
 
+
           = false</font></p>
       <p style="text-align:left;margin-left:0;margin-right:auto;"><strong>34.
+
 
 
 
@@ -4972,8 +5098,10 @@ filename,
 
 
 
+
           = false</font></p>
       <p style="text-align:left;margin-left:0;margin-right:auto;"><strong>35.
+
 
 
 
@@ -5030,6 +5158,7 @@ filename,
 
 
 
+
           = true</font></p>
       <p align="left"><strong>36. MotorEmergencyStopSound</strong> - the
         sound file to play for the elevator motor when an emergency stop
@@ -5061,11 +5190,13 @@ filename,
 
 
 
+
           = emergstop.wav</font></p>
       <p align="left"><strong>37. EmergencyStopSpeed</strong> - the
         speed multiplier to use for an emergency stop. A value of 3, the
         default, would mean 3 times the normal deceleration rate.<br>
         Example: <font size="2" face="Courier New, Courier, mono">EmergencyStopSpeed
+
 
 
 
@@ -5122,8 +5253,10 @@ filename,
 
 
 
+
           = true</font></p>
       <p style="text-align:left;margin-left:0;margin-right:auto;"><strong>39.
+
 
 
 
@@ -5178,8 +5311,10 @@ filename,
 
 
 
+
           = false</font></p>
       <p style="text-align:left;margin-left:0;margin-right:auto;"><strong>40.
+
 
 
 
@@ -5235,8 +5370,10 @@ filename,
 
 
 
+
           = false</font></p>
       <p style="text-align:left;margin-left:0;margin-right:auto;"><strong>41.
+
 
 
 
@@ -5290,11 +5427,13 @@ filename,
 
 
 
+
           = false</font></p>
       <p align="left"><strong>42. RopePosition</strong> - sets the
         position of the rope connection with the elevator. All values
         are relative of the elevator center.<br>
         Syntax: <font size="2" face="Courier New, Courier, mono">RopePosition
+
 
 
 
@@ -5351,10 +5490,12 @@ filename,
 
 
 
+
           = Rope</font></p>
       <p align="left"><strong>44. CounterweightStartSound</strong> - the
         sound file to play for the counterweight when starting movement.<br>
         Example: <font size="2" face="Courier New, Courier, mono">CounterweightStartSound
+
 
 
 
@@ -5409,10 +5550,12 @@ filename,
 
 
 
+
           = weight_move.wav</font></p>
       <p align="left"><strong>46. CounterweightStopSound</strong> - the
         sound file to play for the counterweight when stopping movement.<br>
         Example: <font size="2" face="Courier New, Courier, mono">CounterweightStopSound
+
 
 
 
@@ -5444,6 +5587,7 @@ filename,
       <p align="left"><strong>1. CreateElevator</strong> - creates an
         elevator at the specified location<br>
         Syntax: <font size="2" face="Courier New, Courier, mono">CreateElevator
+
 
 
 
@@ -5510,7 +5654,9 @@ filename,
 
 
 
+
           <em>frame_texture, weight_texture, x</em>, <em>z</em>, <em>size_x,
+
 
 
 
@@ -5579,7 +5725,9 @@ filename,
 
 
 
+
           <em>main_texture, edge_texture, x</em>, <em>z</em>, <em>orientation,
+
 
 
 
@@ -5675,8 +5823,10 @@ filename,
 
 
 
+
           <em>doornumber</em> = <em>value</em></font><br>
         Example: <font size="2" face="Courier New, Courier, mono">OpenSpeed
+
 
 
 
@@ -5734,8 +5884,10 @@ filename,
 
 
 
+
           <em>doornumber</em> = <em>value</em></font><br>
         Example: <font size="2" face="Courier New, Courier, mono">SlowSpeed
+
 
 
 
@@ -5792,8 +5944,10 @@ filename,
 
 
 
+
           <em>doornumber</em> = <em>value</em></font><br>
         Example: <font size="2" face="Courier New, Courier, mono">ManualSpeed
+
 
 
 
@@ -5825,6 +5979,7 @@ filename,
         Ranges can also be specified by putting a "-" between the
         numbers. Please note that each car must serve different floors.<br>
         Example: <font size="2" face="Courier New, Courier, mono">ServicedFloors
+
 
 
 
@@ -5882,8 +6037,10 @@ filename,
 
 
 
+
           <em>doornumber</em> = <em>value</em></font><br>
         Example: <font size="2" face="Courier New, Courier, mono">DoorTimer
+
 
 
 
@@ -5941,8 +6098,10 @@ filename,
 
 
 
+
           <em>doornumber</em> = <em>value</em></font><br>
         Example: <font size="2" face="Courier New, Courier, mono">QuickClose
+
 
 
 
@@ -6000,8 +6159,10 @@ filename,
 
 
 
+
           <em>doornumber</em> = <em>value</em></font><br>
         Example: <font size="2" face="Courier New, Courier, mono">NudgeTimer
+
 
 
 
@@ -6058,8 +6219,10 @@ filename,
 
 
 
+
           <em>doornumber</em> = <em>filename</em></font><br>
         Example: <font size="2" face="Courier New, Courier, mono">OpenSound
+
 
 
 
@@ -6116,8 +6279,10 @@ filename,
 
 
 
+
           <em>doornumber</em> = <em>filename</em></font><br>
         Example: <font size="2" face="Courier New, Courier, mono">CloseSound
+
 
 
 
@@ -6151,6 +6316,7 @@ filename,
         command specifies both up and down sounds, while the others are
         for either upwards movement or downwards movement.<br>
         Example: <font size="2" face="Courier New, Courier, mono">CarStartSound
+
 
 
 
@@ -6210,6 +6376,7 @@ filename,
 
 
 
+
           = move.wav</font></p>
       <p align="left"><strong>13. CarStopSound, CarUpStopSound,
           CarDownStopSound</strong> - the sound file to play when the
@@ -6243,12 +6410,14 @@ filename,
 
 
 
+
           = stop.wav</font></p>
       <p align="left"><strong>14. CarIdleSound</strong> - the sound file
         to play when the elevator car is idle (generally the fan sound).
         Default is <em>elevidle.wav</em>. Leave the filename field
         blank for no sound. <br>
         Example: <font size="2" face="Courier New, Courier, mono">CarIdleSound
+
 
 
 
@@ -6306,8 +6475,10 @@ filename,
 
 
 
+
           <em>doornumber</em> = <em>filename</em></font><br>
         Example: <font size="2" face="Courier New, Courier, mono">ChimeSound
+
 
 
 
@@ -6365,8 +6536,10 @@ filename,
 
 
 
+
           <em>doornumber</em> = <em>filename</em></font><br>
         Example: <font size="2" face="Courier New, Courier, mono">UpChimeSound
+
 
 
 
@@ -6424,8 +6597,10 @@ filename,
 
 
 
+
           <em>doornumber</em> = <em>filename</em></font><br>
         Example: <font size="2" face="Courier New, Courier, mono">DownChimeSound
+
 
 
 
@@ -6483,8 +6658,10 @@ filename,
 
 
 
+
           <em>doornumber</em> = <em>filename</em></font><br>
         Example: <font size="2" face="Courier New, Courier, mono">EarlyUpChimeSound
+
 
 
 
@@ -6542,8 +6719,10 @@ filename,
 
 
 
+
           <em>doornumber</em> = <em>filename</em></font><br>
         Example: <font size="2" face="Courier New, Courier, mono">EarlyDownChimeSound
+
 
 
 
@@ -6600,11 +6779,13 @@ filename,
 
 
 
+
           = bell2.wav</font></p>
       <p align="left"><strong>21. AlarmSoundStop</strong> - the sound
         file to play when the elevator car's alarm button is released.
         Leave the filename field blank for no sound. Default is <em>bell1-stop.wav</em>.<br>
         Example: <font size="2" face="Courier New, Courier, mono">AlarmSoundStop
+
 
 
 
@@ -6637,6 +6818,7 @@ filename,
         enabled. If an asterisk (*) is specified, it is replaced with
         the current floor number.<br>
         Example: <font size="2" face="Courier New, Courier, mono">BeepSound
+
 
 
 
@@ -6695,6 +6877,7 @@ filename,
 
 
 
+
           = floor*.wav</font></p>
       <p align="left"><strong>24. UpMessage</strong> - the notification
         sound file(s) to play after the elevator car arrives at a floor
@@ -6703,6 +6886,7 @@ filename,
         be automatically enabled. If an asterisk (*) is specified, it is
         replaced with the current floor number.<br>
         Example: <font size="2" face="Courier New, Courier, mono">UpMessage
+
 
 
 
@@ -6762,6 +6946,7 @@ filename,
 
 
 
+
           = goingdown.wav</font></p>
       <p align="left"><strong>26. OpenMessage</strong> - the
         notification sound file(s) to play when the elevator doors begin
@@ -6770,6 +6955,7 @@ filename,
         automatically enabled. If an asterisk (*) is specified, it is
         replaced with the current floor number.<br>
         Example: <font size="2" face="Courier New, Courier, mono">OpenMessage
+
 
 
 
@@ -6828,6 +7014,7 @@ filename,
 
 
 
+
           = doorsclosing.wav<br>
         </font></p>
       <p align="left"><strong>28. MessageOnMove</strong> - if set to
@@ -6835,6 +7022,7 @@ filename,
         starts moving, otherwise it'll play after the doors open.&nbsp;
         The default is false.<br>
         Example: <font size="2" face="Courier New, Courier, mono">MessageOnMove
+
 
 
 
@@ -6875,12 +7063,14 @@ filename,
 
 
 
+
           = musicfile.wav</font></p>
       <p align="left"><strong>33. MusicDown</strong> - the sound file to
         play for the elevator car music in the down direction - the
         sound is automatically looped. There is no default; if this is
         set, the sound will be automatically enabled. <br>
         Example: <font size="2" face="Courier New, Courier, mono">MusicDown
+
 
 
 
@@ -6921,8 +7111,10 @@ filename,
 
 
 
+
           <em>doornumber</em> = <em>filename</em></font><br>
         Example: <font size="2" face="Courier New, Courier, mono">NudgeSound
+
 
 
 
@@ -6984,12 +7176,14 @@ filename,
 
 
 
+
           = <em>x, y, z</em><br>
         </font>Example: <font size="2" face="Courier New, Courier,
           mono">MusicPosition = 0, 8, 0</font></p>
       <p align="left"><strong>37. MusicOn</strong> - Enables or disables
         music on start. Default is true.<br>
         Syntax: <font size="2" face="Courier New, Courier, mono">MusicOn
+
 
 
 
@@ -7045,11 +7239,13 @@ filename,
 
 
 
+
           = true</font></p>
       <p align="left"><strong>39. DisplayFloors</strong> - sets the
         floors that will be displayed by the elevator car's indicators.
         This command uses the same syntax as the ServicedFloors command.<br>
         Syntax: <font size="2" face="Courier New, Courier, mono">DisplayFloors
+
 
 
 
@@ -7102,10 +7298,12 @@ filename,
 
 
 
+
           AutoEnable</strong> - Determines if interior objects should
         automatically be enabled or disabled when the user enters/exits
         the elevator car (set to false for glass elevators).<br>
         Syntax: <font size="2" face="Courier New, Courier, mono">AutoEnable
+
 
 
 
@@ -7166,8 +7364,10 @@ filename,
 
 
 
+
           <em>doornumber</em> = <em>enable[, filename]</em></font><br>
         Example: <font size="2" face="Courier New, Courier, mono">DoorSensor
+
 
 
 
@@ -7233,11 +7433,13 @@ filename,
 
 
 
+
           = emergstop_car.wav</font></p>
       <p align="left"><strong>43. IndependentService</strong> - enables
         independent service mode for the elevator, and makes this car
         the active car for the mode.<br>
         Example: <font size="2" face="Courier New, Courier, mono">IndependentService
+
 
 
 
@@ -7269,6 +7471,7 @@ filename,
         makes this car the active car for the mode. Default is 0. Values
         are 0 for off, 1 for on, 2 for hold.<br>
         Syntax: <font size="2" face="Courier New, Courier, mono">FireService2
+
 
 
 
@@ -7328,12 +7531,14 @@ filename,
 
 
 
+
           <em>floor<br>
           </em></font>Example:<font size="2" face="Courier New, Courier,
           mono"><em></em> CreateCar 1</font></p>
       <p align="left"><strong>2. AddFloor</strong> - adds a textured
         floor with the specified dimensions for the car<br>
         Syntax: <font size="2" face="Courier New, Courier, mono">AddFloor
+
 
 
 
@@ -7388,10 +7593,12 @@ filename,
 
 
 
+
           Floor1, Wood2, 0.5, -3.5, -3, 3.5, 3, 0, 0, false, false, 0, 0</font></p>
       <p align="left"><strong>3. AddWall</strong> - adds a textured wall
         for the car<br>
         Syntax: <font size="2" face="Courier New, Courier, mono">AddWall
+
 
 
 
@@ -7446,12 +7653,14 @@ filename,
 
 
 
+
           Wall1, Wood1, 0.5, -3.5, 3, 3.5, 3, 8, 8, 0, 0, 2, 2</font></p>
       <p align="left">The car's AddWall command is similar to the other
         AddWall commands.</p>
       <p align="left"><strong>4. AddDoors</strong> - creates elevator
         car doors<br>
         Syntax: <font size="2" face="Courier New, Courier, mono">AddDoors
+
 
 
 
@@ -7518,6 +7727,7 @@ filename,
 
 
 
+
           <em>number, lefttexture, righttexture</em>, <em>thickness,
             CenterX, CenterZ, voffset, tw, th</em></font></p>
       <p align="left">The AddShaftDoors command creates working elevator
@@ -7540,6 +7750,7 @@ filename,
       <p align="left"><strong>6. CreatePanel</strong> - creates a button
         panel<br>
         Syntax: <font size="2" face="Courier New, Courier, mono">CreatePanel
+
 
 
 
@@ -7616,6 +7827,7 @@ filename,
 
 
 
+
           <em>panel_number, sound, texture_unlit</em>, <em>texture_lit,
             row, column, floor/type, width, height[, hoffset, voffset]</em></font><br>
         Example 1: <font size="2" face="Courier New, Courier, mono">AddButton
@@ -7644,8 +7856,10 @@ filename,
 
 
 
+
           1, switch.wav, Button5, ButtonLit5, 7, 3, 4, 1, 1</font><br>
         Example 2: <font size="2" face="Courier New, Courier, mono">AddButton
+
 
 
 
@@ -7721,6 +7935,7 @@ filename,
 
 
 
+
           <em>panel_number, sound, row, column, width, height, hoffset,
             voffset, selection_position, command_name(s),
             texture_name(s)<br>
@@ -7728,6 +7943,7 @@ filename,
           Courier, mono">AddControl 1, switch.wav, 7, 3, 1, 1, 0, 0, 1,
           open, ButtonOpen</font><br>
         Example 2: <font size="2" face="Courier New, Courier, mono">AddControl
+
 
 
 
@@ -7781,9 +7997,11 @@ filename,
 
 
 
+
           1, switch.wav, 7, 3, 1, 1, 0, 0, 1, Off, 4, Button5,
           ButtonLit5</font><br>
         Example 4: <font size="2" face="Courier New, Courier, mono">AddControl
+
 
 
 
@@ -7962,6 +8180,7 @@ filename,
 
 
 
+
             blank_texture, direction, CenterX, CenterZ, width, height,
             voffset</em></font> </p>
       <p align="left">The AddFloorIndicator command creates a floor
@@ -8003,7 +8222,9 @@ filename,
 
 
 
+
             Single, Vertical, BackTexture</em>, <em>UpTexture</em>, <em>UpTextureLit,
+
 
 
 
@@ -8076,6 +8297,7 @@ filename,
         exterior directional indicator/lanterns (similar to the
         CreateCallButtons command) <br>
         Syntax: <font size="2" face="Courier New, Courier, mono">AddDirectionalIndicators<em>&nbsp;Relative,
+
 
 
 
@@ -8189,6 +8411,7 @@ filename,
 
 
 
+
             relative, texture_prefix, direction, CenterX, CenterZ,
             width, height, voffset</em></font> </p>
       <p align="left">The AddFloorSigns command creates floor signs
@@ -8206,6 +8429,7 @@ filename,
       <p align="left"><strong>14. AddSound</strong> - creates a
         user-defined sound at the specified position<br>
         Syntax: <font size="2" face="Courier New, Courier, mono">AddSound
+
 
 
 
@@ -8261,6 +8485,7 @@ filename,
 
 
 
+
           MySound, sound.wav, 10, 100, 5, true<br>
         </font>Example 2: <font size="2" face="Courier New, Courier,
           mono">AddSound MySound, ambient.ogg, 10, 100, 5, true, 1, 100,
@@ -8274,6 +8499,7 @@ filename,
         single elevator car door component, used for creating custom
         door styles<br>
         Syntax: <font size="2" face="Courier New, Courier, mono">AddDoorComponent
+
 
 
 
@@ -8354,6 +8580,7 @@ filename,
 
 
 
+
           <em>number, name, texture, sidetexture, thickness, direction,
             openspeed, closespeed, x1, z1, x2, z2, height, voffset, tw,
             th, side_tw, side_th</em></font></p>
@@ -8367,6 +8594,7 @@ filename,
         elevator car door creation - use this after all related
         AddDoorComponent commands are used.<br>
         Syntax: <font size="2" face="Courier New, Courier, mono">FinishDoors
+
 
 
 
@@ -8432,6 +8660,7 @@ filename,
 
 
 
+
           <em>number[, door_walls, track_walls]</em></font></p>
       <p align="left">This command is almost identical to the
         FinishDoors command except that it's used for finishing shaft
@@ -8440,6 +8669,7 @@ filename,
         door in the specified location, which moves with the elevator
         car<br>
         Syntax: <font size="2" face="Courier New, Courier, mono">AddDoor
+
 
 
 
@@ -8508,6 +8738,7 @@ filename,
 
 
 
+
             center, CenterX, CenterY, CenterZ, RotationX, RotationY,
             RotationZ, MaxRenderDistance, ScaleMultiplier,
             EnablePhysics, Restitution, Friction, Mass</em><em><br>
@@ -8540,9 +8771,11 @@ filename,
 
 
 
+
           MyModel, cube.mesh, true, 0, 0, 0, 0, 0, 0, 0, 1, true, 0.1,
           0.5, 0.1</font><br>
         Example 3:<font size="2" face="Courier New, Courier, mono">&nbsp;AddModel
+
 
 
 
@@ -8610,9 +8843,11 @@ filename,
 
 
 
+
           AddActionControl</strong> - creates a custom control that uses
         a specific action defined by AddAction.<br>
         Syntax: <font size="2" face="Courier New, Courier, mono">AddActionControl
+
 
 
 
@@ -8685,10 +8920,12 @@ filename,
 
 
 
+
           AddTrigger</strong> - creates a trigger that is used to signal
         an action when the user's camera enters or leaves the defined
         area.<br>
         Syntax:<font size="2" face="Courier New, Courier, mono">&nbsp;AddTrigger
+
 
 
 
@@ -8733,10 +8970,12 @@ filename,
       </p>
       <p style="text-align:left;margin-left:0;margin-right:auto;"><strong>23.
 
+
           AddKeypadIndicator</strong> - creates a keypad indicator for
         this car.<br>
         Syntax: <font size="2"><font face="Courier New, Courier, mono">AddKeypadIndicator</font></font><font
           size="2" face="Courier New, Courier, mono"> <em>sound</em>, <em>texture_prefix,
+
 
 
 
@@ -8788,10 +9027,56 @@ filename,
         simulator will expand it to "Invalid", and "XX" to "Error", so
         as an example the sounds will be "SoundInvalid.wav" and
         "SoundError.wav", if "Sound*.wav" is used for the sound
-        parameter.<em>&nbsp; </em></p>
+        parameter.<em> <br>
+        </em></p>
+      <p align="left"><strong>24. AddElevatorIDSigns</strong> - creates
+        elevator ID signs on all floors serviced by the elevator car<br>
+        Syntax: <font size="2" face="Courier New, Courier, mono">AddElevatorIDSigns<em>&nbsp;door_number,
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+            relative, texture_prefix, direction, CenterX, CenterZ,
+            width, height, voffset</em></font> </p>
+      <p align="left">The AddElevatorIDSigns command creates elevator ID
+        signs on all the floors serviced by the current elevator car. <em>Direction</em>
+        is the direction the signs face, and can be either "left",
+        "right", "front" or "back". <em>Texture_prefix</em> is the base
+        name of the texture to load when displaying an elevator ID; for
+        example if the sign is for an elevator with an ID of A, and you
+        specify a prefix of "Button", it'll load the "ButtonA" texture.
+        <em>Door_number</em> specifies the door number to check against,
+        meaning if shaft doors don't exist on a certain floor for the
+        specified door, the sign won't be created on that floor. This
+        can be bypassed by setting <em>door_number</em> to 0.</p>
+      <p align="left"><br>
+        <em></em></p>
       <p align="left"><br>
       </p>
       <p align="left"><strong><font size="+1"><a name="Controller"></a>8.
+
 
 
 
@@ -8902,10 +9187,12 @@ filename,
 
 
 
+
             = true</font></font></p>
       <p align="left"> </p>
       <br>
       <p align="left"><strong><font size="+1"><a name="CallStation"></a>9.
+
 
 
 
@@ -8948,6 +9235,7 @@ filename,
         <br>
         For a range of call stations, you would use something like:<br>
         <font size="2" face="Courier New, Courier, mono">&lt;CallStations
+
 
 
 
@@ -9066,6 +9354,7 @@ filename,
 
 
 
+
           <em>texturename</em>, <em>rows, columns, direction,
             buttonwidth, buttonheight, spacingX, spacingY, tw, th<br>
           </em></font> Example<font size="2" face="Courier New, Courier,
@@ -9091,6 +9380,7 @@ filename,
       <p align="left"><strong>3. AddControl</strong> - command for
         creating buttons, switches and knobs on the panel<br>
         Syntax: <font size="2" face="Courier New, Courier, mono">AddControl
+
 
 
 
@@ -9150,6 +9440,7 @@ filename,
         destination indicator for this call station<br>
         Syntax: <font size="2"><font face="Courier New, Courier, mono">AddIndicator</font></font><font
           size="2" face="Courier New, Courier, mono"> <em>sound</em>, <em>texture_prefix,
+
 
 
 
@@ -9259,11 +9550,13 @@ filename,
 
 
 
+
           <em>destobject, name, texturename</em>, <em>x1</em>, <em>y1</em>,
           <em>z1</em>, <em>x2</em>, <em>y2</em>, <em>z2</em>, <em>x3</em>,
           <em>y3</em>, <em>z3</em>, <em>tw</em>, <em>th</em></font><br>
         Example: <font size="2" face="Courier New, Courier, mono">AddTrianglewall
 external,
+
 
 
 
@@ -9317,10 +9610,12 @@ external,
 
 
 
+
           <em>destobject, name, texturename</em>, <em>thickness, x1</em>,
           <em>z1</em>, <em>x2</em>, z2, <em>height1</em>, <em>height2</em>,
           <em>altitude1</em>, <em>altitude2</em>, <em>tw</em>, <em>th</em></font><br>
         Example: <font size="2" face="Courier New, Courier, mono">AddWall
+
 
 
 
@@ -9379,6 +9674,7 @@ external,
 
 
 
+
           <em>destobject, name, texturename</em>, <em>thickness, x1</em>,
           <em>z1</em>, <em>x2</em>, <em>z2</em>, <em>altitude1</em>,
           <em>altitude2</em>, reverse_axis, texture_direction, <em>tw</em>,
@@ -9389,6 +9685,7 @@ external,
       <p align="left"><strong>d. AddGround</strong> - adds a tile-based
         ground<br>
         Syntax: <font size="2" face="Courier New, Courier, mono">AddGround
+
 
 
 
@@ -9457,11 +9754,13 @@ external,
 
 
 
+
           <em>destobject</em>, <em>name, texturename</em>, <em>x1</em>,
           <em>x2</em>, <em>z1</em>, <em>z2</em>, <em>height</em>, <em>voffset</em>,
           <em>tw</em>, <em>th, inside, outside, top, bottom </em></font><br>
         Example: <font size="2" face="Courier New, Courier, mono">CreateWallBox
 external,
+
 
 
 
@@ -9524,6 +9823,7 @@ external,
 
 
 
+
           <em>destobject</em>, <em>name, texturename</em>, <em>centerx</em>,
           <em>centerz</em>, <em>widthx</em>, <em>lengthz</em>, <em>height</em>,
           <em>voffset</em>, <em>tw</em>, <em>th</em></font><font
@@ -9531,6 +9831,7 @@ external,
             outside, top, bottom </em></font><br>
         Example: <font size="2" face="Courier New, Courier, mono">CreateWallBox2
 external,
+
 
 
 
@@ -9600,6 +9901,7 @@ external,
 
 
 
+
           <em>destobject, name, texturename[, RelativeY], x1, y1, z1,
             x2, y2, z2, x3, y3, z3, ..., tw, th</em></font><br>
         Example 1: <font size="2" face="Courier New, Courier, mono">AddCustomWall
@@ -9629,10 +9931,12 @@ external,
 
 
 
+
           My Wall, Brick, 0, 0, 0, 0, 10, 0, 10, 10, 0, 15, 5, 0, 10, 0,
           0, 0, 0</font><br>
         Example 2: <font size="2" face="Courier New, Courier, mono">AddCustomWall
 external,
+
 
 
 
@@ -9690,10 +9994,12 @@ external,
 
 
 
+
           <em>destobject, name, texturename, x1, z1, x2, z2, x3, z3,
             ..., altitude, tw, th</em></font><br>
         Example: <font size="2" face="Courier New, Courier, mono">AddCustomFloor
 external,
+
 
 
 
@@ -9748,8 +10054,10 @@ external,
 
 
 
+
           <em>number, centerx, centerz, startfloor, endfloor</em></font><br>
         Example: <font size="2" face="Courier New, Courier, mono">AddShaft
+
 
 
 
@@ -9810,8 +10118,10 @@ external,
 
 
 
+
           <em>number, centerx, centerz, startfloor, endfloor</em></font><br>
         Example: <font size="2" face="Courier New, Courier, mono">CreateStairwell
+
 
 
 
@@ -9872,8 +10182,10 @@ external,
 
 
 
+
           = <em>direction</em></font><br>
         Example: <font size="2" face="Courier New, Courier, mono">WallOrientation
+
 
 
 
@@ -9945,8 +10257,10 @@ external,
 
 
 
+
           = <em>direction</em></font><br>
         Example: <font size="2" face="Courier New, Courier, mono">FloorOrientation
+
 
 
 
@@ -10010,9 +10324,11 @@ external,
 
 
 
+
           = <em>MainNegative, MainPositive, SideNegative, SidePositive,
             Top, Bottom</em></font><br>
         Example: <font size="2" face="Courier New, Courier, mono">DrawWalls
+
 
 
 
@@ -10079,9 +10395,11 @@ external,
 
 
 
+
           <em>Flat, FlipX, FlipY, FlipZ, Rotate</em></font><br>
         Example: <font size="2" face="Courier New, Courier, mono">SetPlanarMapping
 false,
+
 
 
 
@@ -10166,8 +10484,10 @@ false,
 
 
 
+
           <em>vertex1, u1, v1, vertex2, u2, v2, vertex3, u3, v3</em></font><br>
         Example: <font size="2" face="Courier New, Courier, mono">SetTextureMapping
+
 
 
 
@@ -10244,6 +10564,7 @@ false,
 
 
 
+
           0, 0.25, 0.25, 1, 0.75, 0.25, 2, 0.75, 0.75</font></p>
       <p align="left">Here's an easier way to see the example above:</p>
       <p align="left"><font size="2" face="Courier New, Courier, mono">0
@@ -10286,10 +10607,12 @@ false,
 
 
 
+
           <em>v1x, v1y, v1z, u1, v1, v2x, v2y, v2z, u2, v2, v3x, v3y,
             v3z, u3, v3</em></font><br>
         Example: <font size="2" face="Courier New, Courier, mono">SetTextureMapping2
 x0,
+
 
 
 
@@ -10357,6 +10680,7 @@ x0,
 
 
 
+
           y0, z0 -&gt; 0, 0<br>
           x1, y1, z1 -&gt; 1, 0<br>
           x2, y2, z2 -&gt; 1, 1</font></p>
@@ -10389,8 +10713,10 @@ x0,
 
 
 
+
           = <em>default</em></font><br>
         Example: <font size="2" face="Courier New, Courier, mono">ResetTextureMapping
+
 
 
 
@@ -10456,6 +10782,7 @@ x0,
 
 
 
+
           = <em>value</em></font></p>
       <p align="left"><strong>s. ShaftCut</strong> - used in conjunction
         with a shaft object - performs a vertical box cut on all floor
@@ -10487,9 +10814,11 @@ x0,
 
 
 
+
           <em>number, startx, startz, endx, endz, start_voffset,
             end_voffset</em></font><br>
         Example: <font size="2" face="Courier New, Courier, mono">ShaftCut
+
 
 
 
@@ -10561,6 +10890,7 @@ x0,
 
 
 
+
           1, -4, -3.5, 4, 3.5, 0, 5</font></p>
       <p align="left"><strong>u. Isect</strong> - the Isect function
         calculates the position that a line intersects with a certain
@@ -10593,9 +10923,11 @@ objectname,
 
 
 
+
             startx, starty, startz, endx, endy, endz</em>)</font><br>
         Example: <font size="2" face="Courier New, Courier, mono">isect(external,
 wall1,
+
 
 
 
@@ -10668,8 +11000,10 @@ wall1,
 
 
 
+
           = <em>AutoWidth, AutoHeight </em></font><br>
         Example: <font size="2" face="Courier New, Courier, mono">SetAutoSize
+
 
 
 
@@ -10742,11 +11076,13 @@ wall1,
 
 
 
+
           <em>MainNegativeTex, MainPositiveTex, SideNegativeTex,
             SidePositiveTex, TopTex, Bottom</em></font><font size="2"
           face="Courier New, Courier, mono"><em>Tex</em></font><br>
         Example: <font size="2" face="Courier New, Courier, mono">TextureOverride
 Metal1,
+
 
 
 
@@ -10807,6 +11143,7 @@ Metal1,
 
 
 
+
           <em>ShaftNumber</em> = <em>range/list[, full]</em></font><br>
         Example: <font size="2" face="Courier New, Courier, mono">ShaftShowFloors
 
@@ -10834,8 +11171,10 @@ Metal1,
 
 
 
+
           1 = 1 - 10</font><br>
         Example 2: <font size="2" face="Courier New, Courier, mono">ShaftShowFloors
+
 
 
 
@@ -10910,8 +11249,10 @@ Metal1,
 
 
 
+
           <em>ShaftNumber</em> = <em>range/list</em></font><br>
         Example: <font size="2" face="Courier New, Courier, mono">ShaftShowInterfloors
+
 
 
 
@@ -10968,8 +11309,10 @@ Metal1,
 
 
 
+
           <em>ShaftNumber</em> = <em>range/list</em></font><br>
         Example: <font size="2" face="Courier New, Courier, mono">ShaftShowOutside
+
 
 
 
@@ -11037,6 +11380,7 @@ Metal1,
 
 
 
+
           <em>ShaftNumber</em> = <em>value</em></font><br>
         Example: <font size="2" face="Courier New, Courier, mono">ShowFullShaft
 
@@ -11064,8 +11408,10 @@ Metal1,
 
 
 
+
           1 = true</font></p>
       <p style="text-align:left;margin-left:0;margin-right:auto;"><strong>ab.
+
 
 
 
@@ -11119,8 +11465,10 @@ Metal1,
 
 
 
+
           <em>StairwellNumber</em> = <em>range/list</em></font><br>
         Example: <font size="2" face="Courier New, Courier, mono">StairsShowFloors
+
 
 
 
@@ -11179,6 +11527,7 @@ Metal1,
 
 
 
+
           ShowFullStairs</strong> - determines if an entire stairwell
         should be shown. If set to "true" or "inside", the full
         stairwell is shown only when the user is inside the stairwell.
@@ -11211,8 +11560,10 @@ Metal1,
 
 
 
+
           <em>StairwellNumber</em> = <em>value</em></font><br>
         Example: <font size="2" face="Courier New, Courier, mono">ShowFullStairs
+
 
 
 
@@ -11270,9 +11621,11 @@ Metal1,
 
 
 
+
           <em>MainNegative, MainPositive, SideNegative, SidePositive,
             Top, Bottom</em></font><br>
         Example: <font size="2" face="Courier New, Courier, mono">TextureFlip
+
 
 
 
@@ -11309,6 +11662,7 @@ Metal1,
         cut on an object<br>
         Syntax: <font size="2" face="Courier New, Courier, mono">Cut <em>destobject,
 x1,
+
 
 
 
@@ -11380,9 +11734,11 @@ x1,
 
 
 
+
           <em>x1, y1, z1, x2, y2, z2</em></font><br>
         Example: <font size="2" face="Courier New, Courier, mono">AddFloorAutoArea
 -100,
+
 
 
 
@@ -11437,11 +11793,13 @@ x1,
 
 
 
+
           <em>name, filename, x, y, z, loop[, volume, speed,
             min_distance, max_distance, doppler_level,
             cone_inside_angle, cone_outside_angle, cone_outside_volume,
             direction_x, direction_y, direction_z]</em></font><br>
         Example 1: <font size="2" face="Courier New, Courier, mono">AddSound
+
 
 
 
@@ -11523,9 +11881,11 @@ x1,
 
 
 
+
           <em>destobject, wallname, altitude</em></font><br>
         Example: <font size="2" face="Courier New, Courier, mono">GetWallExtents
 external,
+
 
 
 
@@ -11597,9 +11957,11 @@ external,
 
 
 
+
           AddAction</strong> - defines an action, to be used by custom
         controls and triggers.<br>
         Syntax:<font size="2" face="Courier New, Courier, mono">&nbsp;AddAction
+
 
 
 
@@ -11653,9 +12015,11 @@ MyAction,
 
 
 
+
           Floor 2, ChangeTexture, OldTexture, NewTexture</font><br>
         Example:<font size="2" face="Courier New, Courier, mono">&nbsp;AddAction
 MySoundAction,
+
 
 
 
@@ -11696,6 +12060,7 @@ MySoundAction,
         0:Call Panel 1", and can also be specified as a range of
         objects, such as "Floors 3 to 8".</p>
       <p style="text-align:left;margin-left:0;margin-right:auto;">Commands
+
 
 
 
@@ -11787,11 +12152,13 @@ example,
 
 
 
+
         to open elevator 1's shaft doors on floor 2:</p>
       <p style="text-align:left;margin-left:0;margin-right:auto;"><font
           size="2" face="Courier New, Courier, mono">AddAction
           MyDoorOpen, Elevator 1, OpenShaftDoor, 0, 2</font></p>
       <p style="text-align:left;margin-left:0;margin-right:auto;">PlaySound
+
 
 
 
@@ -11860,9 +12227,11 @@ example,
 
 
 
+
           AddActionControl</strong> - creates a custom control that uses
         a specific action defined by AddAction.<br>
         Syntax: <font size="2" face="Courier New, Courier, mono">AddActionControl
+
 
 
 
@@ -11934,10 +12303,12 @@ example,
 
 
 
+
           AddTrigger</strong> - creates a trigger that is used to signal
         an action when the user's camera enters or leaves the defined
         area.<br>
         Syntax:<font size="2" face="Courier New, Courier, mono">&nbsp;AddTrigger
+
 
 
 
@@ -12004,6 +12375,7 @@ example,
 
 
 
+
           AddModel</strong> - adds a global 3D model. If a filename is
         specified, the model's textures/materials must be defined in a
         separate ".material" file, and a separate collider mesh
@@ -12015,6 +12387,7 @@ example,
         automatically created.<br>
         Syntax: <font size="2" face="Courier New, Courier, mono">AddModel<em>&nbsp;name,
 filename,
+
 
 
 
@@ -12072,9 +12445,11 @@ filename,
 
 
 
+
           MyModel, cube.mesh, true, 0, 0, 0, 0, 0, 0, 0, 1, true, 0.1,
           0.5, 0.1</font><br>
         Example 3:<font size="2" face="Courier New, Courier, mono">&nbsp;AddModel
+
 
 
 
@@ -12143,12 +12518,14 @@ filename,
 
 
 
+
           CreateWallObject</strong> - creates a custom wall object, in
         the specified mesh object. Wall objects are used to contain a
         number of polygons, to represent a wall structure, and are
         normally automatically created by other commands. The AddPolygon
         command is used with this command, to create the polygons.<br>
         Syntax:<font size="2" face="Courier New, Courier, mono">&nbsp;CreateWallObject
+
 
 
 
@@ -12201,8 +12578,10 @@ filename,
 
 
 
+
           landscape, mywall</font></p>
       <p style="text-align:left;margin-left:0;margin-right:auto;"><strong>ao.
+
 
 
 
@@ -12263,6 +12642,7 @@ filename,
 
 
 
+
           <em>destobject, wallname, texturename, x1, y1, z1, x2, y2, z2,
             x3, y3, z3, ..., tw, th</em></font><br>
         Example: <font size="2" face="Courier New, Courier, mono">AddPolygon
@@ -12292,8 +12672,10 @@ landscape,
 
 
 
+
           mywall, Brick, 0, 0, 0, 0, 10, 0, 10, 10, 0, 10, 0, 10, 0, 0</font></p>
       <p style="text-align:left;margin-left:0;margin-right:auto;"><strong>ap.
+
 
 
 
@@ -12350,6 +12732,7 @@ landscape,
 
 
 
+
           <em>keyid</em></font><br>
         Example: <font size="2" face="Courier New, Courier, mono">SetKey
 
@@ -12377,8 +12760,10 @@ landscape,
 
 
 
+
           1</font></p>
       <p style="text-align:left;margin-left:0;margin-right:auto;"><strong>aq.
+
 
 
 
@@ -12433,8 +12818,10 @@ landscape,
 
 
 
+
           <em>locked</em>, <em>keyid</em></font><br>
         Example: <font size="2" face="Courier New, Courier, mono">SetLock
+
 
 
 
@@ -12505,6 +12892,7 @@ landscape,
 
 
 
+
           Print</strong> - prints the contents of a line to the console.
         This command will still convert variables and even math
         expressions, and output the results.<br>
@@ -12514,6 +12902,7 @@ landscape,
           1+1</font></p>
       <p style="text-align:left;margin-left:0;margin-right:auto;"></p>
       <p style="text-align:left;margin-left:0;margin-right:auto;"><strong>as.
+
 
 
 
@@ -12569,9 +12958,11 @@ landscape,
 
 
 
+
           12</font></p>
       <p style="text-align:left;margin-left:0;margin-right:auto;"></p>
       <p style="text-align:left;margin-left:0;margin-right:auto;"><strong>at.
+
 
 
 
@@ -12625,8 +13016,10 @@ landscape,
 
 
 
+
           <em>name</em></font><br>
         Example: <font size="2" face="Courier New, Courier, mono">RunAction
+
 
 
 
@@ -12680,9 +13073,11 @@ landscape,
 
 
 
+
           AddActionParent</strong> - adds a parent object to an existing
         action. See the AddAction command for details on parent objects<br>
         Syntax: <font size="2" face="Courier New, Courier, mono">AddActionParent
+
 
 
 
@@ -12736,6 +13131,7 @@ myaction,
 
 
 
+
           Elevator 2</font><br>
         Example: <font size="2" face="Courier New, Courier, mono">AddActionParent
 myaction,
@@ -12764,9 +13160,11 @@ myaction,
 
 
 
+
           Floors 2 to 5</font></p>
       <p style="text-align:left;margin-left:0;margin-right:auto;"></p>
       <p style="text-align:left;margin-left:0;margin-right:auto;"><strong>av.
+
 
 
 
@@ -12822,9 +13220,11 @@ myaction,
 
 
 
+
           <em>name, object</em></font><br>
         Example: <font size="2" face="Courier New, Courier, mono">RemoveActionParent
 myaction,
+
 
 
 
@@ -12878,9 +13278,11 @@ myaction,
 
 
 
+
           Floors 2 to 5</font></p>
       <p style="text-align:left;margin-left:0;margin-right:auto;"></p>
       <p style="text-align:left;margin-left:0;margin-right:auto;"><strong>aw.
+
 
 
 
@@ -12934,8 +13336,10 @@ myaction,
 
 
 
+
           <em>floor</em></font><br>
         Example: <font size="2" face="Courier New, Courier, mono">GotoFloor
+
 
 
 
@@ -12993,8 +13397,10 @@ starty,
 
 
 
+
             angle, distance</em>)</font><br>
         Example: <font size="2" face="Courier New, Courier, mono">endpoint(-150,
+
 
 
 
@@ -13050,9 +13456,11 @@ starty,
 
 
 
+
           FloorInfo</strong> - show information on all floors or
         optionally a specified floor<br>
         Syntax: <font size="2" face="Courier New, Courier, mono">FloorInfo
+
 
 
 
@@ -13105,9 +13513,11 @@ starty,
 
 
 
+
           3</font></p>
       <p style="text-align:left;margin-left:0;margin-right:auto;"></p>
       <p style="text-align:left;margin-left:0;margin-right:auto;"><strong>az.
+
 
 
 
@@ -13163,11 +13573,13 @@ starty,
 
 
 
+
           ListVisibleMeshes</strong> - list the mesh objects currently
         visible by the camera<br>
       </p>
       <p style="text-align:left;margin-left:0;margin-right:auto;"></p>
       <p style="text-align:left;margin-left:0;margin-right:auto;"><strong>bb.
+
 
 
 
@@ -13224,12 +13636,14 @@ starty,
 
 
 
+
           ShowPlayingSounds</strong> - show the sounds currently playing
         in the sound system, with each filename followed by a listing of
         playing sound objects<br>
       </p>
       <p style="text-align:left;margin-left:0;margin-right:auto;"></p>
       <p style="text-align:left;margin-left:0;margin-right:auto;"><strong>bd.
+
 
 
 
@@ -13283,8 +13697,10 @@ starty,
 
 
 
+
           <em>X, Y, Z</em></font><br>
         Example: <font size="2" face="Courier New, Courier, mono">Teleport
+
 
 
 
@@ -13422,6 +13838,7 @@ starty,
           size="2" face="Courier New, Courier, mono"> <em>parent, name,
             X, Y, Z</em></font><br>
         Example: <font size="2"><font face="Courier New, Courier, mono">SetLightDirection
+
 
 
 
@@ -13663,12 +14080,14 @@ starty,
 
 
 
+
           data/scripts/elevator_doors.txt&gt;</font></p>
       <p align="left">You'll then be able to use some predefined door
         functions:</p>
       <p align="left"><strong>1. elevdoor_single</strong> - creates a
         single-slide elevator door.<br>
         Syntax: <font size="2" face="Courier New, Courier, mono">elevdoor_single(<em>door_number,
+
 
 
 
@@ -13729,12 +14148,14 @@ starty,
 
 
 
+
             texture, side_texture, thickness, CenterX, CenterZ, width,
             height, door_direction, speed, is_shaft_door</em>)</font></p>
       <p align="left"><strong>3. elevdoor_center_classic</strong> -
         creates a center-open elevator door with a partially open
         interior door.<br>
         Syntax: <font size="2" face="Courier New, Courier, mono">elevdoor_center_classic(<em>door_number,
+
 
 
 
@@ -13790,11 +14211,13 @@ starty,
 
 
 
+
             texture, side_texture, thickness, CenterX, CenterZ, width,
             height, door_direction, speed, is_shaft_door</em>)</font></p>
       <p align="left"><strong>5. </strong><strong>elevdoor_dualspeed_right</strong>
         - creates a dual-speed door that opens to the right<br>
         Syntax: <font size="2" face="Courier New, Courier, mono">elevdoor_dualspeed_right(<em>door_number,
+
 
 
 
@@ -13850,11 +14273,13 @@ starty,
 
 
 
+
             texture, side_texture, thickness, CenterX, CenterZ, width,
             height, door_direction, speed, is_shaft_door</em>)</font></p>
       <p align="left">&nbsp;</p>
       <div align="center">
         <p align="left"><strong><font size="+1"><a name="Buildings"></a>13.
+
 
 
 
@@ -13909,6 +14334,7 @@ starty,
           set to true, load all buildings simultaneously. Default is
           false, which loads each building in order.<br>
           Example: <font size="2" face="Courier New, Courier, mono">ConcurrentLoads
+
 
 
 
@@ -14010,8 +14436,10 @@ starty,
 
 
 
+
               MinY, MinZ, MaxX, MaxY, MaxZ</em>]</font><br>
           Example 1: <font size="2" face="Courier New, Courier, mono">Load
+
 
 
 
@@ -14064,8 +14492,10 @@ starty,
 
 
 
+
             Simple.bld, 200, 0, 200, 0</font><br>
           Example 3: <font size="2" face="Courier New, Courier, mono">Load
+
 
 
 
@@ -14118,11 +14548,13 @@ starty,
 
 
 
+
             myfolder/mybuilding.bld</font><br>
         </p>
         <p align="left">&nbsp;</p>
         <div align="center">
           <p align="left"><strong><font size="+1"><a name="Vehicles"></a>14.
+
 
 
 
@@ -14187,6 +14619,7 @@ starty,
 
 
 
+
               2 to 10&gt;</font><br>
             and end with:<br>
             <font size="2" face="Courier New, Courier, mono">&lt;EndVehicles&gt;</font></p>
@@ -14198,6 +14631,7 @@ starty,
           <p align="left"><strong>1. Name </strong> - sets the name of
             the vehicle.<br>
             Example: <font size="2" face="Courier New, Courier, mono">Name
+
 
 
 
@@ -14286,6 +14720,7 @@ starty,
 
 
 
+
               = 0, 1, 0</font><br>
           </p>
           <p align="left"><strong>14. ChassisMesh</strong> - defines the
@@ -14301,6 +14736,7 @@ starty,
           <p align="left"><strong>16. ChassisScale</strong> - sets the
             scaling factor for the chassis mesh<br>
             <font size="2" face="Courier New, Courier, mono">ChassisScale
+
 
 
 
@@ -14363,8 +14799,10 @@ starty,
 
 
 
+
               <em>X, Y, Z</em></font><br>
             Example: <font size="2" face="Courier New, Courier, mono">CreateVehicle
+
 
 
 
@@ -14421,9 +14859,11 @@ starty,
 
 
 
+
               <em>restitution, friction, mass, linear_dampening,
                 angular_dampening</em></font><br>
             Example: <font size="2" face="Courier New, Courier, mono">CreateChassis
+
 
 
 
@@ -14485,8 +14925,10 @@ starty,
 
 
 
+
               <em>engine, steerable, IsFrontWheel, radius,
                 ConnectionPointX, ConnectionPointY, ConnectionPointZ</em>[,
+
 
 
 
@@ -14540,10 +14982,12 @@ starty,
 
 
 
+
               true, true, true, 0.3, -1, 0, 0</font><br>
           </p>
           <p align="left">&nbsp;</p>
           <p align="left"><strong><font size="+1"><a name="Example"></a>15.
+
 
 
 

--- a/src/sbs/elevatorcar.cpp
+++ b/src/sbs/elevatorcar.cpp
@@ -3498,4 +3498,65 @@ void ElevatorCar::KeypadError(bool type)
 	UpdateKeypadIndicator(message);
 }
 
+bool ElevatorCar::AddElevatorIDSigns(int door_number, bool relative, const std::string& texture_prefix, const std::string& direction, Real CenterX, Real CenterZ, Real width, Real height, Real voffset)
+{
+	//adds elevator ID signs at the specified position and direction for each serviced floor,
+	//depending on if the given door number services the floor or not (unless door_number is 0)
+
+	Elevator* e = GetElevator();
+
+	Real x, z;
+	if (relative == true)
+	{
+		x = GetPosition().x + CenterX;
+		z = GetPosition().z + CenterZ;
+	}
+	else
+	{
+		x = CenterX;
+		z = CenterZ;
+	}
+
+	//make sure specified door exists before continuing
+	if (door_number != 0)
+	{
+		if (DoorExists(door_number) == false)
+			return ReportError("AddElevatorIDSigns: door " + ToString(door_number) + " does not exist");
+	}
+
+	bool autosize_x, autosize_y;
+	sbs->GetTextureManager()->GetAutoSize(autosize_x, autosize_y);
+	sbs->GetTextureManager()->SetAutoSize(false, false);
+
+	for (size_t i = 0; i < ServicedFloors.size(); i++)
+	{
+		bool door_result = false;
+		int floor = ServicedFloors[i];
+		Real base = GetDestinationOffset(floor);
+
+		if (door_number != 0)
+			door_result = ShaftDoorsExist(door_number, floor);
+
+		if ((door_number == 0 || door_result == true) && sbs->GetFloor(floor))
+		{
+			std::string texture = texture_prefix + e->ID;
+			std::string tmpdirection = direction;
+			SetCase(tmpdirection, false);
+
+			if (tmpdirection == "front" || tmpdirection == "left")
+				sbs->DrawWalls(true, false, false, false, false, false);
+			else
+				sbs->DrawWalls(false, true, false, false, false, false);
+
+			if (tmpdirection == "front" || tmpdirection == "back")
+				sbs->GetFloor(floor)->AddWall("Elevator ID Sign", texture, 0, x - (width / 2), z, x + (width / 2), z, height, height, base + voffset, base + voffset, 1, 1, false);
+			else
+				sbs->GetFloor(floor)->AddWall("Elevator ID Sign", texture, 0, x, z - (width / 2), x, z + (width / 2), height, height, base + voffset, base + voffset, 1, 1, false);
+			sbs->ResetWalls();
+		}
+	}
+	sbs->GetTextureManager()->SetAutoSize(autosize_x, autosize_y);
+	return true;
+}
+
 }

--- a/src/sbs/elevatorcar.cpp
+++ b/src/sbs/elevatorcar.cpp
@@ -3344,6 +3344,22 @@ void ElevatorCar::Requested()
 	//report which elevator is assigned, on indicator
 	std::string message = "Requested";
 
+		Elevator* e = GetElevator();
+
+	//show an error if a floor hasn't been selected due to different factors
+	if (e->InspectionService == true)
+		KeypadError();
+	else if (e->FireServicePhase1 == 1 && e->FireServicePhase2 == 0)
+		KeypadError();
+	else if (e->Running == false)
+		KeypadError();
+	else if (e->IndependentService == true && (AreDoorsOpen() == false || AreDoorsMoving() != 0))
+		KeypadError();
+	else if (e->FireServicePhase2 == 2)
+		KeypadError();
+	else if (e->LimitQueue == true && (e->QueuePositionDirection == 1 && e->UpQueue.size() > 0) || (e->QueuePositionDirection == -1 && e->DownQueue.size() > 0))
+		KeypadError();
+	else
 	UpdateKeypadIndicator(message);
 }
 

--- a/src/sbs/elevatorcar.h
+++ b/src/sbs/elevatorcar.h
@@ -215,6 +215,7 @@ public:
 	CameraTexture* AddCameraTexture(const std::string &name, int quality, Real fov, const Vector3 &position, bool use_rotation, const Vector3 &rotation);
 	bool RespondingToCall(int floor, int direction);
 	int RespondingToCall(int floor);
+	bool AddElevatorIDSigns(int door_number, bool relative, const std::string& texture_prefix, const std::string& direction, Real CenterX, Real CenterZ, Real width, Real height, Real voffset);
 
 	MeshObject* Mesh; //car mesh object
 

--- a/src/script/elevatorcars.cpp
+++ b/src/script/elevatorcars.cpp
@@ -2359,6 +2359,66 @@ int ScriptProcessor::ElevatorCarSection::Run(std::string &LineData)
 		}
 	}
 
+	//AddElevatorIDSigns command
+	if (StartsWithNoCase(LineData, "addelevatoridsigns"))
+	{
+		//get data
+		int params = SplitData(LineData, 18);
+
+		if (params < 7 || params > 9)
+			return ScriptError("Incorrect number of parameters");
+
+		int compat = 0;
+		if (params == 7)
+			compat = 1; //1.4 compatibility mode
+		if (params == 8)
+			compat = 2; //1.5 compatibility mode
+
+		//check numeric values
+		if (compat == 0)
+		{
+			for (int i = 0; i <= 8; i++)
+			{
+				if (i == 1)
+					i = 4;
+				if (!IsNumeric(tempdata[i]))
+					return ScriptError("Invalid value: " + tempdata[i]);
+			}
+		}
+		else if (compat == 1)
+		{
+			for (int i = 2; i <= 6; i++)
+			{
+				if (!IsNumeric(tempdata[i]))
+					return ScriptError("Invalid value: " + tempdata[i]);
+			}
+		}
+		else if (compat == 2)
+		{
+			for (int i = 3; i <= 7; i++)
+			{
+				if (!IsNumeric(tempdata[i]))
+					return ScriptError("Invalid value: " + tempdata[i]);
+			}
+		}
+
+		if (compat > 0 && warn_deprecated == true)
+			ScriptWarning("Syntax deprecated");
+
+		if (compat == 0)
+		{
+			bool result;
+			result = car->AddElevatorIDSigns(ToInt(tempdata[0]), ToBool(tempdata[1]), tempdata[2], tempdata[3], ToFloat(tempdata[4]), ToFloat(tempdata[5]), ToFloat(tempdata[6]), ToFloat(tempdata[7]), ToFloat(tempdata[8]));
+			if (result == false)
+				return ScriptError();
+		}
+		else if (compat == 1)
+			car->AddElevatorIDSigns(0, ToBool(tempdata[0]), "Button", tempdata[1], ToFloat(tempdata[2]), ToFloat(tempdata[3]), ToFloat(tempdata[4]), ToFloat(tempdata[5]), ToFloat(tempdata[6]));
+		else if (compat == 2)
+			car->AddElevatorIDSigns(0, ToBool(tempdata[0]), tempdata[1], tempdata[2], ToFloat(tempdata[3]), ToFloat(tempdata[4]), ToFloat(tempdata[5]), ToFloat(tempdata[6]), ToFloat(tempdata[7]));
+		return sNextLine;
+	}
+
 	return sContinue;
 }
 


### PR DESCRIPTION
Here’s a new command that adds Elevator ID signs, good for Destination Dispatch elevators. I also made it so that the keypad indicator shows an error if a floor isn’t selected due to different factors.

EDIT: I’m not sure if the one involving LimitQueue fully works, so I may need to test it later before this is merged.